### PR TITLE
🔒 Fix missing rel="noopener noreferrer" on target="_blank" links

### DIFF
--- a/src/app/certification-journey/page.tsx
+++ b/src/app/certification-journey/page.tsx
@@ -167,6 +167,7 @@ const CertificationJourneyPage = () => {
                     : "text-cyan-600 hover:text-cyan-800"
                 }`}
                 target="_blank"
+                rel="noopener noreferrer"
               >
                 IBM AI Engineer Professional Certificate on Coursera
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/components/ModuleCard.tsx
+++ b/src/components/ModuleCard.tsx
@@ -122,6 +122,7 @@ const ModuleCard: React.FC<ModuleCardProps> = ({
                 key={lab.title}
                 href={lab.link}
                 target="_blank"
+                rel="noopener noreferrer"
                 className={`group/lab flex items-center p-3 rounded-xl border transition-all duration-200 ${
                   isDarkMode
                     ? "bg-ai-navy/30 border-ai-slate/30 hover:bg-ai-navy hover:border-ai-cyan/50 focus:ring-ai-cyan"


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the missing `rel="noopener noreferrer"` attribute on external links that use `target="_blank"`.

⚠️ **Risk:** Without `rel="noopener noreferrer"`, the newly opened page can access the original page's window object via `window.opener`. This could allow a malicious site to redirect the original page to a phishing site, a technique known as reverse tabnabbing.

🛡️ **Solution:** Added `rel="noopener noreferrer"` to all identified instances where `target="_blank"` was used without these security attributes. This ensures that the new browsing context does not have access back to the originating window and hides referrer information for privacy and security.


---
*PR created automatically by Jules for task [291806263512304715](https://jules.google.com/task/291806263512304715) started by @muzammil5539*