### PR TITLE
⚡ memoize ThemeContext provider value

### DIFF
--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { createContext, useContext, useState, useEffect } from "react";
+import { createContext, useContext, useState, useEffect, useMemo, useCallback } from "react";
 
 type ThemeContextType = {
   isDarkMode: boolean;
@@ -34,12 +34,17 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     }
   }, [isDarkMode, isInitialized]);
 
-  const toggleTheme = () => {
-    setIsDarkMode(!isDarkMode);
-  };
+  const toggleTheme = useCallback(() => {
+    setIsDarkMode(prev => !prev);
+  }, []);
+
+  const value = useMemo(() => ({
+    isDarkMode,
+    toggleTheme
+  }), [isDarkMode, toggleTheme]);
 
   return (
-    <ThemeContext.Provider value={{ isDarkMode, toggleTheme }}>
+    <ThemeContext.Provider value={value}>
       {children}
     </ThemeContext.Provider>
   );


### PR DESCRIPTION
💡 **What:** Memoized the `ThemeContext.Provider` value using `useMemo` and the `toggleTheme` function using `useCallback`.
🎯 **Why:** Without memoization, a new object reference is created for the context value on every render of `ThemeProvider`. This triggers a re-render of all components that consume the context (using `useTheme`), even if `isDarkMode` hasn't changed.
📊 **Measured Improvement:** While direct performance metrics (like render times) are difficult to measure without a full browser environment and complex component tree, this change is a standard React performance optimization that reduces the number of re-renders for all context consumers from $O(R)$ to $O(S)$, where $R$ is the number of provider re-renders and $S$ is the number of state changes. This is particularly beneficial as the app grows and more components consume the theme context.

---
*PR created automatically by Jules for task [5514894275476915632](https://jules.google.com/task/5514894275476915632) started by @muzammil5539*